### PR TITLE
Update example usage in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   plugins: [prometheusPlugin(register, { enableNodeMetrics: true })],
+  tracing: true
 });
 
 server.applyMiddleware({ app, path: '/' });


### PR DESCRIPTION
Without `tracing: true`, the `total_request_time` histogram is not collected; this is not clear from the README at present.